### PR TITLE
Fixed margin issue on landing page that was affecting all the other p…

### DIFF
--- a/app/assets/stylesheets/pages/_landing.scss
+++ b/app/assets/stylesheets/pages/_landing.scss
@@ -31,7 +31,7 @@ h2 {
   visibility: hidden;
 }
 
-body{
-  margin-top:0px;
+.body-landing{
+  margin-top: 0px;
   margin-bottom: 0px;
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', defer: true %>
     <script src="https://code.iconify.design/2/2.2.1/iconify.min.js"></script>
   </head>
-  <body>
+  <body class=<%= yield(:body_class)%> >
     <head>
     <%= render 'shared/navbar' %>
     </head>

--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:body_class, "body-landing") %>
 <% content_for(:navbar_class, "navbar-landing") %>
 <% content_for(:footer_class, "footer-landing") %>
 <div class="banner">


### PR DESCRIPTION
There was a problem with the top and bottom margins that was caused when I created the landing page. I fixed the problem by creating a "body-landing" class that removes the margin on that page only and keeps the margin on all other pages.

Consider the following screenshots
1- The landing shows the picture covering the entire body
2- The item show page which shows that the navbar and footer are not overlapping content

![image](https://user-images.githubusercontent.com/50388199/171744597-f8e3bf91-46ce-4e1b-ae9b-0cb8a36e4fee.png)
![image](https://user-images.githubusercontent.com/50388199/171744659-21e153b5-472a-453b-9883-f8e78bb08cfa.png)
