### PR TITLE
Uncommented forcing SSL in prod env

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).


### PR DESCRIPTION
Hi @andking, @Suebxl  and @MarkSoosaipillai ,

Happy new year! I hope this message finds you well.

This pull request is for enabling our website to have a secure connection (currently there is a Not Secure message displayed in the Chrome address bar).  You can find the details as to why this change is necessary on this [Heroku support  page](https://help.heroku.com/J2R1S4T8/can-heroku-force-an-application-to-use-ssl-tls).

Would one of you please approve this PR? Thank you in advance :-) 

